### PR TITLE
Fix bug: expected 1 line replaced but actual 2 lines replaced

### DIFF
--- a/src/buffer/basic-text-buffer.ts
+++ b/src/buffer/basic-text-buffer.ts
@@ -101,11 +101,6 @@ export class BasicTextBuffer implements TextBuffer {
         let prefixChars: string[] = [];
 
         for (let i = start.line; i <= end.line; i++) {
-            if (i > start.line) {
-                if (this.isLineEmpty(line)) {
-                    this.removeLine(line);
-                }
-            }
 
             const colEnd = (i === end.line) ? end.column : this.getColumnCount(line);
 
@@ -113,7 +108,7 @@ export class BasicTextBuffer implements TextBuffer {
                 this.removeColumn(startCol, line);
             }
 
-            if (!this.isLineEmpty(line)) {
+            if (!this.isLineEmpty(line) || i === end.line) {
 
                 if (i !== end.line) {
                     prefixChars = this.table[line];
@@ -122,6 +117,8 @@ export class BasicTextBuffer implements TextBuffer {
                 } else {
                     this.table[line] = prefixChars.concat(this.table[line]);
                 }
+            } else {
+                this.removeLine(line);
             }
         }
 

--- a/test/buffer-test.js
+++ b/test/buffer-test.js
@@ -154,6 +154,24 @@ describe('Test TextBuffer methods', function () {
             data.should.equal('\nHello, World\n');
         });
 
+        it('Should have text that contains "\nHello,\nWorld"', () => {
+            const buffer = textModule.createBuffer('\nHello,\n\nWorld');
+            const range = textModule.createTextRange({column: 6, line: 1}, {column: 0, line: 2});
+            buffer.replaceRange(range, '');
+
+            const data = buffer.getText();
+            data.should.equal('\nHello,\nWorld');
+        });
+
+        it('Should have text that contains "\nHello,\nWorld"', () => {
+            const buffer = textModule.createBuffer('\nHello,\n\nWorld');
+            const range = textModule.createTextRange({column: 0, line: 2}, {column: 0, line: 3});
+            buffer.replaceRange(range, '');
+
+            const data = buffer.getText();
+            data.should.equal('\nHello,\nWorld');
+        });
+
         it('Should have text that contains "Hello, World"', () => {
             const buffer = textModule.createBuffer('');
             const range = textModule.createTextRange({column: 0, line: 0}, {column: 0, line: 0});


### PR DESCRIPTION
I found an empty-line replace bug.

It's expected 1 line replaced but actual 2 lines replaced.

I added 2 test cases.

Thank you.